### PR TITLE
chore: use pubkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ sanctum-rewards --help
 ```bash
 Calculate the total block rewards earned by your validator for a specific epoch.
 
-Usage: sanctum-rewards calculate [OPTIONS] --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
+Usage: sanctum-rewards calculate [OPTIONS]
 
 Options:
-      --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
-          The identity keypair of your validator
+      --identity-pubkey <IDENTITY_PUBKEY>
+          The identity pubkey of your validator
 
       --epoch <EPOCH>
           The epoch to calculate rewards for
@@ -58,11 +58,11 @@ This command:
 ```bash
 Calculate the total block rewards earned by your validator for a specific epoch.
 
-Usage: sanctum-rewards calculate-with-dune [OPTIONS] --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
+Usage: sanctum-rewards calculate-with-dune [OPTIONS]
 
 Options:
-      --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
-          The identity keypair of your validator
+      --identity-pubkey <IDENTITY_PUBKEY>
+          The identity pubkey of your validator
 
       --dune-api-key <DUNE_API_KEY>
           Dune API key
@@ -92,11 +92,14 @@ This command:
 ```bash
 Transfer block rewards to the stake pool reserve
 
-Usage: sanctum-rewards transfer [OPTIONS] --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
+Usage: sanctum-rewards transfer [OPTIONS] --payer <PAYER>
 
 Options:
-      --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
-          The identity keypair for your validator
+      --payer <PAYER>
+          Path to the keypair from where rewards will be transferred
+
+      --identity-pubkey <IDENTITY_PUBKEY>
+          The identity pubkey of your validator
 
       --epoch <EPOCH>
           The epoch to calculate rewards for
@@ -118,23 +121,3 @@ This command:
 - Loads previously calculated rewards data
 - Transfers the specified percentage of rewards to the stake pool reserve
 - Updates stake pool balance by calling `UpdateStakePoolBalance` instruction
-
-### `sign`
-
-```bash
-Sign message to endorse your Sanctum LST
-
-Usage: sanctum-rewards sign --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
-
-Options:
-      --identity-keypair-path <IDENTITY_KEYPAIR_PATH>
-          The identity keypair for your validator
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-This command:
-- Prompts the user to sign the message
-- Prints the signed message
-- Reach out to us on Telegram @fp_lee with your signed message

--- a/src/solana_utils.rs
+++ b/src/solana_utils.rs
@@ -171,6 +171,7 @@ pub async fn get_total_block_rewards_for_slots(
 
 pub async fn transfer_to_reserve_and_update_stake_pool_balance_ixs(
     rpc: &RpcClient,
+    payer_pubkey: &Pubkey,
     identity_pubkey: &Pubkey,
     stake_pool_pubkey: &Pubkey,
     lst_rewards: u64,
@@ -203,7 +204,7 @@ pub async fn transfer_to_reserve_and_update_stake_pool_balance_ixs(
 
     let final_ixs = vec![
         // Transfer rewards to Stake Pool reserve
-        transfer(identity_pubkey, &stake_pool.reserve_stake, lst_rewards),
+        transfer(payer_pubkey, &stake_pool.reserve_stake, lst_rewards),
         // Update stake pool balance
         update_stake_pool_balance_ix_with_program_id(
             stake_pool_program_id,

--- a/src/subcmd/calculate.rs
+++ b/src/subcmd/calculate.rs
@@ -191,6 +191,12 @@ impl CalculateArgs {
                     .yellow()
                     .bold()
             );
+            println!(
+                "{}",
+                "⚠️ We also have a `calculate-with-dune` command that also calulcates block rewards but using Dune Analytics."
+                    .yellow()
+                    .bold()
+            );
         }
 
         println!("{}", "=".repeat(80));

--- a/src/subcmd/calculate.rs
+++ b/src/subcmd/calculate.rs
@@ -1,24 +1,25 @@
 use crate::{
     get_leader_slots_for_identity, get_rewards_file_path, get_total_block_rewards_for_slots,
-    input_with_validation, subcmd::Subcmd, validate_epoch, validate_rpc_url, SOLANA_PUBLIC_RPC,
+    input_string, input_with_validation, subcmd::Subcmd, validate_epoch, validate_rpc_url,
+    SOLANA_PUBLIC_RPC,
 };
 use clap::{command, Args};
 use colored::Colorize;
 use inquire::Confirm;
-use sanctum_solana_cli_utils::{parse_named_signer, ParseNamedSigner, TokenAmt};
+use sanctum_solana_cli_utils::TokenAmt;
 use serde_json::{json, Value};
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use spinners::{Spinner, Spinners};
-use std::{fs::File, path::Path};
+use std::{fs::File, path::Path, str::FromStr};
 
 #[derive(Args, Debug)]
 #[command(
     long_about = "Calculate the total block rewards earned by your validator for a specific epoch."
 )]
 pub struct CalculateArgs {
-    #[arg(long, help = "The identity keypair of your validator")]
-    pub identity_keypair_path: String,
+    #[arg(long, help = "The identity pubkey of your validator")]
+    pub identity_pubkey: Option<String>,
     #[arg(long, help = "The epoch to calculate rewards for")]
     pub epoch: Option<u64>,
 }
@@ -26,11 +27,32 @@ pub struct CalculateArgs {
 impl CalculateArgs {
     pub async fn run(args: crate::Args) {
         let Self {
-            identity_keypair_path,
+            identity_pubkey,
             epoch,
         } = match args.subcmd {
             Subcmd::Calculate(args) => args,
             _ => unreachable!(),
+        };
+
+        let identity_pubkey = match input_string(
+            "Enter your validator's identity key:",
+            "Identity key",
+            None,
+            identity_pubkey,
+        ) {
+            Ok(key) => key,
+            Err(_) => {
+                println!("{}", "Error: Invalid identity key".red());
+                return;
+            }
+        };
+
+        let identity_pubkey = match Pubkey::from_str(&identity_pubkey) {
+            Ok(pubkey) => pubkey,
+            Err(_) => {
+                println!("{}", "Error: Invalid identity pubkey".red());
+                return;
+            }
         };
 
         let rpc_url = match input_with_validation(
@@ -75,19 +97,6 @@ impl CalculateArgs {
             }
         };
         println!("{}", "=".repeat(80));
-
-        let identity_keypair = match parse_named_signer(ParseNamedSigner {
-            name: "identity",
-            arg: &identity_keypair_path,
-        }) {
-            Ok(keypair) => keypair,
-            Err(_) => {
-                println!("{}", "Error: Invalid identity keypair".red());
-                return;
-            }
-        };
-
-        let identity_pubkey = identity_keypair.pubkey();
 
         // Check if rewards file exists
         let rewards_file_path = match get_rewards_file_path(&identity_pubkey, epoch) {

--- a/src/subcmd/transfer.rs
+++ b/src/subcmd/transfer.rs
@@ -109,8 +109,8 @@ impl TransferArgs {
 
         let payer_pubkey = payer_keypair.pubkey();
 
-        let (current_epoch_info, identity_balance) =
-            match tokio::try_join!(rpc.get_epoch_info(), rpc.get_balance(&identity_pubkey)) {
+        let (current_epoch_info, payer_balance) =
+            match tokio::try_join!(rpc.get_epoch_info(), rpc.get_balance(&payer_pubkey)) {
                 Ok(result) => result,
                 Err(_) => {
                     println!("{}", "Error: Failed to fetch data from RPC".red());
@@ -253,7 +253,7 @@ impl TransferArgs {
 
         print_transfer_summary(PrintTransferSummaryArgs {
             epoch,
-            identity_balance,
+            payer_balance,
             total_block_rewards,
             total_rewards_bps,
             stake_pool_rewards,

--- a/src/subcmd/transfer.rs
+++ b/src/subcmd/transfer.rs
@@ -1,8 +1,9 @@
 use crate::{
-    checked_pct, get_lst_info, get_rewards_file_path, handle_tx_full, input_with_validation,
-    print_transfer_summary, subcmd::Subcmd, transfer_to_reserve_and_update_stake_pool_balance_ixs,
-    validate_bps, validate_epoch, validate_pubkey, validate_rpc_url, with_auto_cb_ixs,
-    PrintTransferSummaryArgs, SOLANA_PUBLIC_RPC,
+    checked_pct, get_lst_info, get_rewards_file_path, handle_tx_full, input_string,
+    input_with_validation, print_transfer_summary, subcmd::Subcmd,
+    transfer_to_reserve_and_update_stake_pool_balance_ixs, validate_bps, validate_epoch,
+    validate_pubkey, validate_rpc_url, with_auto_cb_ixs, PrintTransferSummaryArgs,
+    SOLANA_PUBLIC_RPC,
 };
 use clap::{command, Args};
 use colored::Colorize;
@@ -10,14 +11,20 @@ use inquire::Confirm;
 use sanctum_solana_cli_utils::{parse_named_signer, ParseNamedSigner, TxSendMode};
 use serde_json::Value;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
-use std::{fs::File, path::Path};
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
+use std::{fs::File, path::Path, str::FromStr};
 
 #[derive(Args, Debug)]
 #[command(long_about = "Transfer block rewards to the stake pool reserve")]
 pub struct TransferArgs {
-    #[arg(long, help = "The identity keypair for your validator")]
-    pub identity_keypair_path: String,
+    #[arg(
+        long,
+        help = "Path to the keypair from where rewards will be transferred"
+    )]
+    pub payer: String,
+
+    #[arg(long, help = "The identity pubkey of your validator")]
+    pub identity_pubkey: Option<String>,
 
     #[arg(long, help = "The epoch to calculate rewards for")]
     pub epoch: Option<u64>,
@@ -38,7 +45,8 @@ pub struct TransferArgs {
 impl TransferArgs {
     pub async fn run(args: crate::Args) {
         let Self {
-            identity_keypair_path,
+            payer,
+            identity_pubkey,
             epoch,
             stake_pool_pubkey,
             total_rewards_pct,
@@ -46,6 +54,27 @@ impl TransferArgs {
         } = match args.subcmd {
             Subcmd::Transfer(a) => a,
             _ => unreachable!(),
+        };
+
+        let identity_pubkey = match input_string(
+            "Enter your validator's identity key:",
+            "Identity key",
+            None,
+            identity_pubkey,
+        ) {
+            Ok(key) => key,
+            Err(_) => {
+                println!("{}", "Error: Invalid identity key".red());
+                return;
+            }
+        };
+
+        let identity_pubkey = match Pubkey::from_str(&identity_pubkey) {
+            Ok(pubkey) => pubkey,
+            Err(_) => {
+                println!("{}", "Error: Invalid identity pubkey".red());
+                return;
+            }
         };
 
         let rpc_url = match input_with_validation(
@@ -67,9 +96,9 @@ impl TransferArgs {
             args.commitment.unwrap_or(CommitmentConfig::confirmed()),
         );
 
-        let identity_keypair = match parse_named_signer(ParseNamedSigner {
-            name: "identity",
-            arg: &identity_keypair_path,
+        let payer_keypair = match parse_named_signer(ParseNamedSigner {
+            name: "payer",
+            arg: &payer,
         }) {
             Ok(keypair) => keypair,
             Err(_) => {
@@ -78,7 +107,7 @@ impl TransferArgs {
             }
         };
 
-        let identity_pubkey = identity_keypair.pubkey();
+        let payer_pubkey = payer_keypair.pubkey();
 
         let (current_epoch_info, identity_balance) =
             match tokio::try_join!(rpc.get_epoch_info(), rpc.get_balance(&identity_pubkey)) {
@@ -262,6 +291,7 @@ impl TransferArgs {
 
         let final_ixs = match transfer_to_reserve_and_update_stake_pool_balance_ixs(
             &rpc,
+            &payer_pubkey,
             &identity_pubkey,
             &stake_pool_pubkey,
             lst_rewards,
@@ -285,6 +315,6 @@ impl TransferArgs {
             println!("{}", "Transaction Message:".blue().bold());
         }
 
-        handle_tx_full(&rpc, send_mode, &final_ixs, &[], &mut [&identity_keypair]).await;
+        handle_tx_full(&rpc, send_mode, &final_ixs, &[], &mut [&payer_keypair]).await;
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -144,7 +144,7 @@ pub fn validate_pubkey(input: &str) -> Result<Pubkey, String> {
 
 pub struct PrintTransferSummaryArgs {
     pub epoch: u64,
-    pub identity_balance: u64,
+    pub payer_balance: u64,
     pub total_block_rewards: u64,
     pub total_rewards_bps: u64,
     pub stake_pool_rewards: u64,
@@ -155,7 +155,7 @@ pub struct PrintTransferSummaryArgs {
 pub fn print_transfer_summary(args: PrintTransferSummaryArgs) {
     let PrintTransferSummaryArgs {
         epoch,
-        identity_balance,
+        payer_balance,
         total_block_rewards,
         total_rewards_bps,
         stake_pool_rewards,
@@ -217,7 +217,7 @@ pub fn print_transfer_summary(args: PrintTransferSummaryArgs) {
         format!(
             "{} SOL",
             TokenAmt {
-                amt: identity_balance,
+                amt: payer_balance,
                 decimals: 9
             }
         )
@@ -230,7 +230,7 @@ pub fn print_transfer_summary(args: PrintTransferSummaryArgs) {
         "Post Transfer balance: ".blue().bold(),
         {
             let post_balance = TokenAmt {
-                amt: identity_balance - lst_rewards,
+                amt: payer_balance.saturating_sub(lst_rewards),
                 decimals: 9,
             };
             let formatted = format!("{} SOL", post_balance);


### PR DESCRIPTION
### Description

This PR refactors all commands to now require the `Pubkey` of the identity account of the validator instead of the `Keypair`.

For `transfer`, we take a `identity_pubkey` argument along with the **new** `payer` argument which is the path to the keypair from where the rewards will be transferred into the stake pool reserve, along with updating the stake pool balance in the same transaction.

This `payer` keypair could be the identity keypair, or any other keypair from where the user may want to transfer rewards from.