### PR TITLE
fix: handle skipped slot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "sanctum_block_rewards_cli"
 
 [dependencies]
 clap = { version = "^4", features = ["derive"] }
-tokio = { version = "^1", features = ["rt-multi-thread"] }
+tokio = { version = "^1", features = ["rt-multi-thread", "test-util"] }
 borsh = "^1"
 indicatif = "0.17.11"
 futures = "0.3.31"

--- a/src/solana_utils.rs
+++ b/src/solana_utils.rs
@@ -33,6 +33,8 @@ use std::fmt::Write;
 
 const CU_BUFFER_RATIO: f64 = 1.1;
 const CUS_REQUIRED_FOR_SET_CU_LIMIT_IXS: u32 = 300;
+
+// https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/rpc-client-api/src/custom_error.rs#L17C1-L17C60
 const JSON_RPC_ERROR_CODE_SKIPPED_SLOT: i64 = -32007;
 
 pub async fn with_auto_cb_ixs(
@@ -164,7 +166,6 @@ pub async fn get_total_block_rewards_for_slots(
             Err(e) => match e.kind {
                 ClientErrorKind::RpcError(rpc_error) => match rpc_error {
                     RpcError::RpcResponseError { code, .. } => {
-                        // https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/rpc-client-api/src/custom_error.rs#L17C1-L17C60
                         if code == JSON_RPC_ERROR_CODE_SKIPPED_SLOT {
                             None
                         } else {


### PR DESCRIPTION
### Description

This PR fixes a bug where we weren't handling the case for when a validator skips a slot (or fails to produce a block). We know from [here](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/rpc-client-api/src/custom_error.rs#L17C1-L17C60) that the JSON-RPC error code for skipped slot is `-32007` and hence when we come across this code, we simply skip that slot. 

In the case of any other error, we stop the calculation for now so that we don't end up calculating the block rewards incorrectly.